### PR TITLE
Fix downloading scripts from voxedit by enabling network access

### DIFF
--- a/io.github.mgerhardy.vengi.voxedit.yml
+++ b/io.github.mgerhardy.vengi.voxedit.yml
@@ -12,6 +12,8 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --filesystem=home
+  # Required for downloading scripts from voxedit.
+  - --share=network
 cleanup:
   - /include
   - /share/man


### PR DESCRIPTION
Tested locally, it works as expected.

- This closes https://github.com/flathub/io.github.mgerhardy.vengi.voxedit/issues/24.
