### PR TITLE
Compile with `RelWithDebInfo` build type to improve performance

### DIFF
--- a/io.github.mgerhardy.vengi.voxedit.yml
+++ b/io.github.mgerhardy.vengi.voxedit.yml
@@ -47,6 +47,7 @@ modules:
       - -DVOXCONVERT=OFF
       - -DTHUMBNAILER=OFF
       - -DPKGDATADIR=/app/share/vengi/
+      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
     sources:
       - type: git
         url: https://github.com/mgerhardy/vengi


### PR DESCRIPTION
- This closes https://github.com/flathub/io.github.mgerhardy.vengi.voxedit/issues/25.

Confirmed by the About dialog no longer having a warning about being a debug build:

<img width="320" height="134" alt="image" src="https://github.com/user-attachments/assets/b1763f34-297a-4b4c-b726-ce6f218c1269" />
